### PR TITLE
Fix property typo in story.rb

### DIFF
--- a/lib/clubhouse2/story.rb
+++ b/lib/clubhouse2/story.rb
@@ -2,7 +2,7 @@ module Clubhouse
 	class Story < ClubhouseResource
 		def self.properties
 			[
-				:archived, :blocker, :blocker, :comment_ids, :completed, :completed_at, :completed_at_override, :created_at,
+				:archived, :blocker, :blocked, :comment_ids, :completed, :completed_at, :completed_at_override, :created_at,
 				:deadline, :entity_type, :epic_id, :estimate, :external_id, :file_ids, :follower_ids, :id,
 				:linked_file_ids, :moved_at, :name, :owner_ids, :position, :project_id, :requested_by_id, :started,
 				:started_at, :started_at_override, :story_type, :task_ids, :updated_at, :workflow_state_id,


### PR DESCRIPTION
Caught this when trying to find out if a story was blocked or not.  This fixed it up for me.