### PR TITLE
Improve Date parsing to include time

### DIFF
--- a/lib/clubhouse2/clubhouse_resource.rb
+++ b/lib/clubhouse2/clubhouse_resource.rb
@@ -58,7 +58,7 @@ module Clubhouse
 		end
 
 		def value_format(key, value)
-			Date.iso8601(value) rescue value
+			DateTime.strptime(value+'+0000', '%Y-%m-%dT%H:%M:%SZ%z') rescue value
 		end
 
 		# Empties resource cache


### PR DESCRIPTION
I improved the parsing of the date fields returned by the API to:
* Use DateTime instead of Date .. b/c time is useful for intraday tracking
* Get really pedantic on the exact format expected, so various things DateTime would otherwise parse (like an Epic name 'Week 20') would not slip through
* Force UTC on the parsing... just in case.  better safe than sorry.