### PR TITLE
Fix TypeError (class or module required) crash when validating labels

### DIFF
--- a/lib/clubhouse2/story.rb
+++ b/lib/clubhouse2/story.rb
@@ -39,7 +39,7 @@ module Clubhouse
 			end
 
 			(args[:labels] || []).collect! do |this_label|
-				this_label.is_a? Label ? this_label : @client.label(id: this_label['name'])
+				this_label.is_a?(Label) ? this_label : @client.label(id: this_label['name'])
 			end
 		end
 


### PR DESCRIPTION
For #11